### PR TITLE
remove private variables from flush

### DIFF
--- a/lib/Dancer2/Session/CGISession.pm
+++ b/lib/Dancer2/Session/CGISession.pm
@@ -83,6 +83,9 @@ sub _flush {
     my ( $class, $id, $data ) = @_;
 
     my $cgi_session = $class->get_cgi_session( $id );
+    foreach my $key (keys %{$data} ){
+        delete $$data{$key} if ($key =~ m/^_SESSION_/);
+    }
     $cgi_session->param( %{$data} );
     $cgi_session->flush;
 }


### PR DESCRIPTION
As per issue #1 a pull request that removes the private variables from the CGISession flush routine.

Tested only using file storage.
