### PR TITLE
Add support for change_session_id

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Dancer2-Session-CGISession
 
 {{$NEXT}}
+        - Add support for Dancer2's upcoming change_session_id app method
 
 0.03  2016-05-20 14:32:16 SGT
         - Fix an issue with CGI default variable

--- a/lib/Dancer2/Session/CGISession.pm
+++ b/lib/Dancer2/Session/CGISession.pm
@@ -56,6 +56,13 @@ sub generate_id {
     return $cgi_session->id();
 }
 
+sub _change_id {
+    my ( $self, $old_id, $new_id ) = @_;
+    my $data = $self->_retrieve($old_id);
+    $self->_destroy($old_id);
+    $self->_flush($new_id, $data);
+}
+
 sub _retrieve {
     my ( $class, $id ) = @_;
 

--- a/lib/Dancer2/Session/CGISession.pm
+++ b/lib/Dancer2/Session/CGISession.pm
@@ -147,6 +147,8 @@ Pierre VIGIER E<lt>pierre.vigier@gmail.comE<gt>
 
 jwilliams99 E<lt>https://github.com/jwilliams99E<gt>
 
+Peter Mottram (SysPete) E<lt>peter@sysnix.comE<gt>
+
 =head1 COPYRIGHT
 
 Copyright 2015- Pierre VIGIER

--- a/t/lifecycle.t
+++ b/t/lifecycle.t
@@ -20,6 +20,16 @@ get '/read_session' => sub {
     return "name='$name'";
 };
 
+get 'change_session_id' => sub {
+    if ( app->can('change_session_id') ) {
+        app->change_session_id;
+        return "supported";
+    }
+    else {
+        return "change_session_id not supported in this Dancer2 release";
+    }
+};
+
 get '/destroy_session' => sub {
     my $name = session('name') || '';
     app->destroy_session;
@@ -57,6 +67,29 @@ ok( $res->is_success, 'Successful request' );
 $jar->extract_cookies($res);
 ok( $jar->as_string, 'Session created, cookie set' );
 my $jar_content = $jar->as_string;
+
+$req = GET 'http://localhost/read_session';
+$jar->add_cookie_header($req);
+$res = $test->request( $req );
+ok( $res->is_success, 'Successful request' );
+is( $res->content, "name='John'", 'Correct value retrieved from session');
+$jar->extract_cookies($res);
+ok( $jar->as_string, 'Cookie is still there' );
+is( $jar->as_string, $jar_content, "Session cookie did not change");
+$jar_content = $jar->as_string;
+
+$req = GET 'http://localhost/change_session_id';
+$jar->add_cookie_header($req);
+$res = $test->request( $req );
+ok( $res->is_success, 'Successful request /change_session_id' );
+$jar->extract_cookies($res);
+if ( $res->content eq 'supported' ) {
+    isnt( $jar->as_string, $jar_content, "Session cookie changed");
+}
+else {
+    is( $jar->as_string, $jar_content, "Session cookie did not change");
+}
+$jar_content = $jar->as_string;
 
 $req = GET 'http://localhost/read_session';
 $jar->add_cookie_header($req);


### PR DESCRIPTION
Soon Dancer2 will have a new app method `change_session_id` which allows session ID to be changed when privilege levels change (login, etc). This PR adds tests which this module passes via D2 compat code for change_session_id and also adds native support which will eventually be required by all session engines.
